### PR TITLE
Add pharmaceutical label SVG asset

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 Welcome to **your** repository for your GitHub Learning Lab course. This repository will be used during the different activities that I will be guiding you through. See a word you don't understand? We've included an emoji 📖 next to some key terms. Click on it to see its definition.
 
+## Pharmaceutical label asset
+
+The `assets/six-synth-peptides-label.svg` file contains a 40mm × 20mm precision pharmaceutical label for the SIX SYNTH PEPTIDES Retatrutide 20mg concept. The artwork is built as a print-ready vector following the provided color, typography, and geometric specifications.
+
 Oh! I haven't introduced myself...
 
 I'm the GitHub Learning Lab bot and I'm here to help guide you in your journey to learn and master the various topics covered in this course. I will be using Issue and Pull Request comments to communicate with you. In fact, I already added an issue for you to check out.

--- a/assets/six-synth-peptides-label.svg
+++ b/assets/six-synth-peptides-label.svg
@@ -1,0 +1,213 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="40mm" height="20mm" viewBox="0 0 40 20" version="1.1">
+  <title>SIX SYNTH PEPTIDES Retatrutide Label</title>
+  <defs>
+    <linearGradient id="bgGradient" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#091626" />
+      <stop offset="50%" stop-color="#0F1E35" />
+      <stop offset="100%" stop-color="#15263F" />
+    </linearGradient>
+    <pattern id="hexPattern" x="0" y="0" width="1.2" height="0.6928" patternUnits="userSpaceOnUse" patternTransform="translate(0,0)">
+      <polygon points="0.4,0 0.8,0.1732 0.8,0.5196 0.4,0.6928 0,0.5196 0,0.1732" fill="none" stroke="#1A3D5A" stroke-width="0.05" />
+      <polygon points="1.0,0.1732 1.4,0.3464 1.4,0.6928 1.0,0.866 0.6,0.6928 0.6,0.3464" fill="none" stroke="#1A3D5A" stroke-width="0.05" />
+    </pattern>
+    <radialGradient id="particleGradient" cx="50%" cy="50%" r="50%">
+      <stop offset="0%" stop-color="#00A3CC" stop-opacity="0.8" />
+      <stop offset="80%" stop-color="#00A3CC" stop-opacity="0.2" />
+      <stop offset="100%" stop-color="#00A3CC" stop-opacity="0" />
+    </radialGradient>
+    <linearGradient id="ringCyan" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#00C8FF" />
+      <stop offset="100%" stop-color="#0095CC" />
+    </linearGradient>
+    <linearGradient id="ringGold" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#C4982D" />
+      <stop offset="100%" stop-color="#E6B445" />
+    </linearGradient>
+    <linearGradient id="brandSilver" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#FAFBFC" />
+      <stop offset="100%" stop-color="#D4D9DF" />
+    </linearGradient>
+    <linearGradient id="brandCyan" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0%" stop-color="#00D9FF" />
+      <stop offset="100%" stop-color="#00B8E6" />
+    </linearGradient>
+    <linearGradient id="compoundGold" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#E6B957" />
+      <stop offset="100%" stop-color="#C29640" />
+    </linearGradient>
+    <filter id="softGlow" x="-20%" y="-20%" width="140%" height="140%">
+      <feGaussianBlur stdDeviation="0.6" result="blur" />
+      <feColorMatrix in="blur" type="matrix" values="0 0 0 0 0  0 0 0 0 0.72  0 0 0 0 0.9  0 0 0 0.25 0" />
+    </filter>
+    <filter id="outerGlow" x="-30%" y="-30%" width="160%" height="160%">
+      <feGaussianBlur stdDeviation="1.4" result="blur" />
+      <feColorMatrix in="blur" type="matrix" values="0 0 0 0 0.1  0 0 0 0 0.2  0 0 0 0 0.35  0 0 0 0.15 0" />
+    </filter>
+    <filter id="brandShadow" x="-20%" y="-20%" width="140%" height="140%">
+      <feDropShadow dx="0" dy="0.12" stdDeviation="0.08" flood-color="#000000" flood-opacity="0.18" />
+    </filter>
+    <filter id="subtitleShadow" x="-20%" y="-20%" width="140%" height="140%">
+      <feDropShadow dx="0.12" dy="0.15" stdDeviation="0.1" flood-color="#001B2E" flood-opacity="0.3" />
+    </filter>
+    <filter id="compoundGlow" x="-20%" y="-20%" width="140%" height="140%">
+      <feGaussianBlur stdDeviation="0.3" result="blur" />
+      <feColorMatrix in="blur" type="matrix" values="0 0 0 0 1  0 0 0 0 0.85  0 0 0 0 0.54  0 0 0 0.22 0" />
+    </filter>
+    <filter id="regGlow" x="-20%" y="-20%" width="140%" height="140%">
+      <feGaussianBlur stdDeviation="0.12" result="blur" />
+      <feColorMatrix in="blur" type="matrix" values="0 0 0 0 0.91  0 0 0 0 0.93  0 0 0 0 0.94  0 0 0 0.15 0" />
+    </filter>
+    <filter id="noise" x="0" y="0" width="100%" height="100%" filterUnits="objectBoundingBox">
+      <feTurbulence type="fractalNoise" baseFrequency="1.2" numOctaves="2" seed="12" result="noise" />
+      <feColorMatrix in="noise" type="saturate" values="0" />
+      <feComponentTransfer>
+        <feFuncR type="linear" slope="0.01" />
+        <feFuncG type="linear" slope="0.01" />
+        <feFuncB type="linear" slope="0.01" />
+      </feComponentTransfer>
+    </filter>
+    <linearGradient id="reflection" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#FFFFFF" stop-opacity="0.02" />
+      <stop offset="60%" stop-color="#FFFFFF" stop-opacity="0" />
+      <stop offset="100%" stop-color="#FFFFFF" stop-opacity="0" />
+    </linearGradient>
+    <radialGradient id="cornerShade" cx="0" cy="0" r="1">
+      <stop offset="0%" stop-color="#000000" stop-opacity="0.05" />
+      <stop offset="100%" stop-color="#000000" stop-opacity="0" />
+    </radialGradient>
+  </defs>
+
+  <rect width="40" height="20" fill="url(#bgGradient)" />
+  <rect width="40" height="20" fill="url(#hexPattern)" opacity="0.05" style="mix-blend-mode:screen" />
+
+  <g opacity="0.03" style="mix-blend-mode:soft-light">
+    <circle cx="25.354" cy="1.26" r="0.219" fill="url(#particleGradient)" />
+    <circle cx="9.371" cy="14.351" r="0.319" fill="url(#particleGradient)" />
+    <circle cx="35.06" cy="2.4" r="0.255" fill="url(#particleGradient)" />
+    <circle cx="1.944" cy="4.823" r="0.276" fill="url(#particleGradient)" />
+    <circle cx="1.819" cy="4.459" r="0.312" fill="url(#particleGradient)" />
+    <circle cx="21.726" cy="4.856" r="0.297" fill="url(#particleGradient)" />
+    <circle cx="31.882" cy="0.92" r="0.351" fill="url(#particleGradient)" />
+    <circle cx="27.609" cy="7.061" r="0.189" fill="url(#particleGradient)" />
+    <circle cx="37.557" cy="6.993" r="0.173" fill="url(#particleGradient)" />
+    <circle cx="4.514" cy="16.394" r="0.301" fill="url(#particleGradient)" />
+    <circle cx="31.794" cy="14.227" r="0.284" fill="url(#particleGradient)" />
+    <circle cx="38.168" cy="7.765" r="0.288" fill="url(#particleGradient)" />
+    <circle cx="32.649" cy="12.181" r="0.365" fill="url(#particleGradient)" />
+    <circle cx="22.97" cy="13.764" r="0.161" fill="url(#particleGradient)" />
+    <circle cx="9.551" cy="6.125" r="0.17" fill="url(#particleGradient)" />
+    <circle cx="9.739" cy="2.658" r="0.219" fill="url(#particleGradient)" />
+    <circle cx="25.21" cy="7.513" r="0.243" fill="url(#particleGradient)" />
+    <circle cx="8.845" cy="5.712" r="0.384" fill="url(#particleGradient)" />
+    <circle cx="25.685" cy="12.008" r="0.193" fill="url(#particleGradient)" />
+    <circle cx="28.798" cy="3.807" r="0.245" fill="url(#particleGradient)" />
+    <circle cx="38.798" cy="12.576" r="0.289" fill="url(#particleGradient)" />
+    <circle cx="27.089" cy="16.308" r="0.344" fill="url(#particleGradient)" />
+    <circle cx="9.595" cy="1.391" r="0.229" fill="url(#particleGradient)" />
+    <circle cx="11.081" cy="4.682" r="0.386" fill="url(#particleGradient)" />
+    <circle cx="34.453" cy="6.59" r="0.314" fill="url(#particleGradient)" />
+    <circle cx="15.992" cy="17.628" r="0.265" fill="url(#particleGradient)" />
+    <circle cx="10.971" cy="5.338" r="0.29" fill="url(#particleGradient)" />
+    <circle cx="10.889" cy="11.556" r="0.374" fill="url(#particleGradient)" />
+    <circle cx="16.137" cy="4.836" r="0.399" fill="url(#particleGradient)" />
+    <circle cx="20.366" cy="2.473" r="0.162" fill="url(#particleGradient)" />
+    <circle cx="5.011" cy="12.345" r="0.348" fill="url(#particleGradient)" />
+    <circle cx="17.011" cy="1.969" r="0.245" fill="url(#particleGradient)" />
+    <circle cx="39.051" cy="10.536" r="0.393" fill="url(#particleGradient)" />
+    <circle cx="33.854" cy="1.011" r="0.33" fill="url(#particleGradient)" />
+    <circle cx="26.978" cy="10.68" r="0.217" fill="url(#particleGradient)" />
+    <circle cx="25.413" cy="2.853" r="0.259" fill="url(#particleGradient)" />
+    <circle cx="18.223" cy="18.35" r="0.369" fill="url(#particleGradient)" />
+    <circle cx="10.914" cy="10.011" r="0.195" fill="url(#particleGradient)" />
+    <circle cx="35.845" cy="16.818" r="0.225" fill="url(#particleGradient)" />
+    <circle cx="25.336" cy="12.005" r="0.188" fill="url(#particleGradient)" />
+    <circle cx="30.08" cy="10.725" r="0.345" fill="url(#particleGradient)" />
+    <circle cx="21.166" cy="0.811" r="0.231" fill="url(#particleGradient)" />
+    <circle cx="1.548" cy="17.895" r="0.37" fill="url(#particleGradient)" />
+    <circle cx="32.736" cy="6.458" r="0.164" fill="url(#particleGradient)" />
+    <circle cx="34.516" cy="18.224" r="0.171" fill="url(#particleGradient)" />
+  </g>
+
+  <rect x="1.8" y="1.8" width="36.4" height="16.4" fill="none" stroke="#B4BEC8" stroke-width="0.25" opacity="0.35" />
+
+  <g transform="translate(8.5 11)">
+    <circle cx="0" cy="0" r="1.5" fill="#00B8E6" opacity="0.25" filter="url(#softGlow)" />
+    <circle cx="0" cy="0" r="3" fill="#1A2E4A" opacity="0.15" filter="url(#outerGlow)" />
+
+    <circle cx="0" cy="0" r="0.45" fill="#FFFFFF" />
+    <circle cx="0" cy="0" r="1.25" fill="none" stroke="url(#ringCyan)" stroke-width="0.3" />
+    <circle cx="0" cy="0" r="2.125" fill="none" stroke="#1A3D66" stroke-width="0.25" />
+    <circle cx="0" cy="0" r="3.1" fill="none" stroke="url(#ringGold)" stroke-width="0.4" />
+    <circle cx="0" cy="0" r="4.1" fill="none" stroke="#C0CAD4" stroke-width="0.2" />
+
+    <g stroke="#0099CC" stroke-width="0.15" stroke-opacity="0.4">
+      <line x1="3.5" y1="0" x2="9.5" y2="0" />
+      <line x1="-3.5" y1="0" x2="-9.5" y2="0" />
+      <line x1="0" y1="3.5" x2="0" y2="9.5" />
+      <line x1="0" y1="-3.5" x2="0" y2="-9.5" />
+      <line x1="2.475" y1="2.475" x2="6.717" y2="6.717" />
+      <line x1="-2.475" y1="2.475" x2="-6.717" y2="6.717" />
+      <line x1="2.475" y1="-2.475" x2="6.717" y2="-6.717" />
+      <line x1="-2.475" y1="-2.475" x2="-6.717" y2="-6.717" />
+    </g>
+    <g fill="#B8C2CC">
+      <circle cx="9.5" cy="0" r="0.25" />
+      <circle cx="-9.5" cy="0" r="0.25" />
+      <circle cx="0" cy="9.5" r="0.25" />
+      <circle cx="0" cy="-9.5" r="0.25" />
+      <circle cx="6.717" cy="6.717" r="0.25" />
+      <circle cx="-6.717" cy="6.717" r="0.25" />
+      <circle cx="6.717" cy="-6.717" r="0.25" />
+      <circle cx="-6.717" cy="-6.717" r="0.25" />
+    </g>
+    <g stroke="#C0CAD4" stroke-width="0.08">
+      <line x1="0" y1="-4.2" x2="0" y2="-4.8" />
+      <line x1="4.2" y1="0" x2="4.8" y2="0" />
+      <line x1="0" y1="4.2" x2="0" y2="4.8" />
+      <line x1="-4.2" y1="0" x2="-4.8" y2="0" />
+    </g>
+  </g>
+
+  <g filter="url(#noise)" opacity="0.6">
+    <rect width="40" height="20" fill="#808080" opacity="0.01" />
+  </g>
+  <rect width="40" height="20" fill="url(#reflection)" />
+  <g opacity="1">
+    <rect width="8" height="8" fill="url(#cornerShade)" transform="translate(0 0)" />
+    <rect width="8" height="8" fill="url(#cornerShade)" transform="translate(40 0) scale(-1 1)" />
+    <rect width="8" height="8" fill="url(#cornerShade)" transform="translate(0 20) scale(1 -1)" />
+    <rect width="8" height="8" fill="url(#cornerShade)" transform="translate(40 20) scale(-1 -1)" />
+  </g>
+
+  <g filter="url(#brandShadow)">
+    <text x="20" y="2.3" font-family="'Helvetica Neue', Arial, 'Akzidenz-Grotesk', sans-serif" font-size="6.5pt" font-weight="700" letter-spacing="-0.3" text-anchor="middle" fill="url(#brandSilver)" stroke="#B0B8C0" stroke-width="0.06" paint-order="stroke fill">
+      <tspan dx="0">S</tspan><tspan>IX</tspan>
+      <tspan dx="-0.08em"> </tspan>
+      <tspan>SY</tspan><tspan dx="-0.05em">N</tspan><tspan>TH</tspan>
+    </text>
+    <text x="20" y="2.3" font-family="'Helvetica Neue', Arial, 'Akzidenz-Grotesk', sans-serif" font-size="6.5pt" font-weight="700" letter-spacing="-0.3" text-anchor="middle" fill="none" stroke="#FFFFFF" stroke-width="0.08" opacity="0.35" paint-order="stroke">
+      <tspan dx="0">S</tspan><tspan>IX</tspan>
+      <tspan dx="-0.08em"> </tspan>
+      <tspan>SY</tspan><tspan dx="-0.05em">N</tspan><tspan>TH</tspan>
+    </text>
+  </g>
+  <g filter="url(#subtitleShadow)">
+    <text x="20" y="2.9" font-family="'Helvetica Neue', Arial, 'Akzidenz-Grotesk', sans-serif" font-size="6.5pt" font-weight="700" letter-spacing="-0.3" text-anchor="middle" fill="url(#brandCyan)" stroke="#0099CC" stroke-width="0.06" paint-order="stroke fill">
+      <tspan dx="0">PE</tspan><tspan>PTI</tspan><tspan>DES</tspan>
+    </text>
+  </g>
+
+  <g text-anchor="middle" font-family="'Helvetica Neue', Arial, sans-serif">
+    <text x="20" y="12.8" font-size="5.8pt" font-weight="500" letter-spacing="-0.15" fill="url(#compoundGold)" stroke="#8B6914" stroke-width="0.05" paint-order="stroke fill" filter="url(#compoundGlow)">
+      <tspan>Re</tspan><tspan dx="-0.4">ta</tspan><tspan dx="-0.3">tru</tspan><tspan dx="-0.3">ti</tspan><tspan dx="-0.5">de</tspan><tspan dx="1"> </tspan><tspan>20mg</tspan>
+    </text>
+    <text x="20" y="16.2" font-size="6.2pt" font-weight="900" letter-spacing="0.25" fill="#000000" filter="url(#softGlow)">
+      <tspan dx="-0.02em">HI</tspan><tspan dx="-0.03em">G</tspan><tspan>H</tspan><tspan dx="-0.03em">E</tspan><tspan>ST</tspan><tspan dx="-0.02em"> </tspan><tspan dx="-0.02em">AB</tspan><tspan dx="-0.04em">I</tspan><tspan>LI</tspan><tspan dx="-0.03em">TY</tspan>
+    </text>
+    <line x1="9" x2="31" y1="16.55" y2="16.55" stroke="#D4A74F" stroke-width="0.22" />
+    <text x="20" y="19" font-size="3pt" font-weight="400" letter-spacing="0" fill="#CED6DD" text-rendering="optimizeLegibility" filter="url(#regGlow)">
+      Not for Human Use. Research Use Only
+    </text>
+  </g>
+
+</svg>


### PR DESCRIPTION
## Summary
- add a 40mm × 20mm print-ready SVG for the SIX SYNTH PEPTIDES Retatrutide 20mg label following the detailed visual specification
- document the location of the new label asset in the README

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6953995988bc83309fa34c912db8ac3e)